### PR TITLE
add missed header declaration

### DIFF
--- a/miner.h
+++ b/miner.h
@@ -161,6 +161,8 @@ extern int scanhash_quark(int thr_id, uint32_t *pdata,
 	
 extern void init_quarkhash_contexts();	
 
+extern void init_Xhash_contexts();
+
 //----------- X
 extern int scanhash_X(int thr_id, uint32_t *pdata,
 	const uint32_t *ptarget, uint32_t max_nonce, unsigned long *hashes_done);


### PR DESCRIPTION
fixes build error
```
cpu-miner.c:1360:17: error: implicit declaration of function ‘init_Xhash_contexts’;
```